### PR TITLE
初始化优化

### DIFF
--- a/setter.go
+++ b/setter.go
@@ -12,7 +12,14 @@ func (c Carbon) SetTimezone(name string) Carbon {
 
 // Timezone 设置时区
 func SetTimezone(name string) Carbon {
-	loc, err := getLocationByTimezone(name)
+	var loc *time.Location
+	var err error
+	if name == Local {
+		loc = time.Local
+	} else {
+		loc, err = getLocationByTimezone(name)
+	}
+
 	return Carbon{Loc: loc, Error: err, Lang: NewLanguage()}
 }
 


### PR DESCRIPTION
初始化默认时区时使用time.local全局变量