### PR TITLE
Fixes in RO Language, proposed fix in function "ToFormatString" for specific symbols

### DIFF
--- a/lang/ro.json
+++ b/lang/ro.json
@@ -1,10 +1,10 @@
 {
 	"months": "Ianuarie|Februarie|Martie|Aprilie|Mai|Iunie|Iulie|August|Septembrie|Octombrie|Noiembrie|Decembrie",
 	"short_months": "Ian|Feb|Mar|Apr|Mai|Iun|Iul|Aug|Sep|Oct|Noi|Dec",
-	"weeks": "Duminica|Luni|Marti|Miercuri|Joi|Vineri|Sîmbătă",
+	"weeks": "Duminică|Luni|Marți|Miercuri|Joi|Vineri|Sîmbătă",
 	"short_weeks": "Dum|Lun|Mar|Mie|Joi|Vin|Sîm",
 	"seasons": "Primăvara|Vara|Toamna|Iarna",
-	"constellations": "Berbec|Taur|Gemeni|Rac|Leu|Fecioară|Balanță|Scorpion|Săgetător|Capricorn|Vărsator|Pești",
+	"constellations": "Berbec|Taur|Gemeni|Rac|Leu|Fecioară|Balanță|Scorpion|Săgetător|Capricorn|Vărsător|Pești",
 	"year": "1 an|%d ani",
 	"month": "1 lună|%d luni",
 	"week": "1 săptămînă|%d săptămîni",

--- a/outputer.go
+++ b/outputer.go
@@ -714,7 +714,18 @@ func (c Carbon) ToFormatString(format string, timezone ...string) string {
 	buffer := bytes.NewBuffer(nil)
 	for i := 0; i < len(format); i++ {
 		if layout, ok := formats[format[i]]; ok {
-			buffer.WriteString(c.Carbon2Time().Format(layout))
+			switch format[i] {
+			case 'D': // Mon
+				buffer.WriteString(c.ToShortWeekString())
+			case 'l': // Monday
+				buffer.WriteString(c.ToWeekString())
+			case 'F': // January
+				buffer.WriteString(c.ToMonthString())
+			case 'M': // Jan
+				buffer.WriteString(c.ToShortMonthString())
+			default:
+				buffer.WriteString(c.Carbon2Time().Format(layout))
+			}
 		} else {
 			switch format[i] {
 			case '\\': // 原样输出，不解析


### PR DESCRIPTION
**_Changelog:_**
**1. Fixes in RO Language**
**2. Function "ToFormatString" from outputer.go wasn't translating by current set Locale for symbols: "D","l","F","M".**
**Therefore some exceptions were added for them.
A simple example for testing would be (set any other language except English):**
log.Println(carbon.Now().SetLocale("ro").Format("d F Y"))
log.Println(carbon.Now().SetLocale("ru").Format("d F Y"))
log.Println(carbon.Now().SetLocale("zh-CN").Format("d F Y"))
**The expected Output should be:**
2022/05/20 15:06:31 20 Mai 2022
2022/05/20 15:06:31 20 Май 2022
2022/05/20 15:06:31 20 五月 2022