### PR TITLE
lang: added ms-my.json for Bahasa Malaysia in Malaysia (country)

### DIFF
--- a/lang/ms-MY.json
+++ b/lang/ms-MY.json
@@ -1,0 +1,20 @@
+{
+	"months": "Januari|Februari|Mac|April|Mei|Jun|Julai|Ogos|September|Oktober|November|Disember",
+	"short_months": "Jan|Feb|Mac|Apr|Mei|Jun|Jul|Ogs|Sep|Okt|Nov|Dis",
+	"weeks": "Ahad|Isnin|Selasa|Rabu|Khamis|Jumaat|Sabtu",
+	"short_weeks": "Ahd|Isn|Sel|Rab|Kha|Jum|Sab",
+	"seasons": "Musim Bunga|Musim Panas|Musim Luruh|Musim Sejuk",
+	"constellations": "Aries|Taurus|Gemini|Cancer|Leo|Virgo|Libra|Scorpio|Sagittarius|Capricorn|Aquarius|Pisces",
+	"year": "1 tahun|%d tahun",
+	"month": "1 bulan|%d bulan",
+	"week": "1 minggu|%d minggu",
+	"day": "1 hari|%d hari",
+	"hour": "1 jam|%d jam",
+	"minute": "1 minit|%d minit",
+	"second": "1 saat|%d saat",
+	"now": "baru tadi",
+	"ago": "%s lalu",
+	"from_now": "%s dari sekarang",
+	"before": "sebelum %s",
+	"after": "selepas %s"
+}


### PR DESCRIPTION
Since the i18n language is missing of Bahasa Malaysia for Malaysia while our other native languages (English [en], and Simplified Chinese [zh-CN]) are available, I, as a Malaysian who understands all these languages shall contribute the missing piece.

The language code is 'ms' but 'my' country code is required as the Bahasa Malaysia language itself is known closely related across the South East Asia coutries (variations in different countries like Singapore and Brunei). The only exception is Bahasa Indonesia where it has its own code (id).

This patch adds ms-my.json for Bahasa Malaysia specifically for Malaysia in South East Asia.

Signed-off-by: (Holloway) Chew, Kean Ho <hollowaykeanho@gmail.com>