### PR TITLE
Json time-only layouts

### DIFF
--- a/creator.go
+++ b/creator.go
@@ -4,6 +4,59 @@ import (
 	"time"
 )
 
+// CreateFromLayoutString creates a Carbon instance from a given string.
+func CreateFromLayoutString(value, layout string, timezone ...string) Carbon {
+	return ParseByLayout(value, layout, timezone...)
+}
+
+// CreateFromTimeLayoutString creates a Carbon instance from a given TimeLayout string ("15:04:05").
+// 从给定的秒级时间戳创建 Carbon 实例
+func (Carbon) CreateFromTimeLayoutString(timeString string, timezone ...string) Carbon {
+	return CreateFromLayoutString(timeString, TimeLayout, timezone...)
+}
+
+// CreateFromTimeLayoutString creates a Carbon instance from a given TimeLayout string ("15:04:05").
+// 从给定的秒级时间戳创建 Carbon 实例
+func CreateFromTimeLayoutString(timeString string, timezone ...string) Carbon {
+	return NewCarbon().CreateFromTimeLayoutString(timeString, timezone...)
+}
+
+// CreateFromTimeMilliLayoutString creates a Carbon instance from a given TimeMilliLayout string ("15:04:05.999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func (Carbon) CreateFromTimeMilliLayoutString(timeMilliString string, timezone ...string) Carbon {
+	return CreateFromLayoutString(timeMilliString, TimeMilliLayout, timezone...)
+}
+
+// CreateFromTimeMilliLayoutString creates a Carbon instance from a given TimeMilliLayout string ("15:04:05.999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func CreateFromTimeMilliLayoutString(timeMilliString string, timezone ...string) Carbon {
+	return NewCarbon().CreateFromTimeMilliLayoutString(timeMilliString, timezone...)
+}
+
+// CreateFromTimeMicroLayoutString creates a Carbon instance from a given TimeMicroLayout string ("15:04:05.999999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func (Carbon) CreateFromTimeMicroLayoutString(timeMicroString string, timezone ...string) Carbon {
+	return CreateFromLayoutString(timeMicroString, TimeMicroLayout, timezone...)
+}
+
+// CreateFromTimeMicroLayoutString creates a Carbon instance from a given TimeMicroLayout string ("15:04:05.999999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func CreateFromTimeMicroLayoutString(timeMicroString string, timezone ...string) Carbon {
+	return NewCarbon().CreateFromTimeMicroLayoutString(timeMicroString, timezone...)
+}
+
+// CreateFromTimeNanoLayoutString creates a Carbon instance from a given TimeNanoLayout string ("15:04:05.999999999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func (Carbon) CreateFromTimeNanoLayoutString(timeNanoString string, timezone ...string) Carbon {
+	return CreateFromLayoutString(timeNanoString, TimeNanoLayout, timezone...)
+}
+
+// CreateFromTimeNanoLayoutString creates a Carbon instance from a given TimeNanoLayout string ("15:04:05.999999999").
+// 从给定的秒级时间戳创建 Carbon 实例
+func CreateFromTimeNanoLayoutString(timeNanoString string, timezone ...string) Carbon {
+	return NewCarbon().CreateFromTimeNanoLayoutString(timeNanoString, timezone...)
+}
+
 // CreateFromTimestamp creates a Carbon instance from a given timestamp with second.
 // 从给定的秒级时间戳创建 Carbon 实例
 func (c Carbon) CreateFromTimestamp(timestamp int64, timezone ...string) Carbon {

--- a/json.go
+++ b/json.go
@@ -6,6 +6,30 @@ import (
 	"strconv"
 )
 
+// Time defines a Time struct.
+// 定义 Time 结构体
+type Time struct {
+	Carbon
+}
+
+// TimeMilli defines a TimeMilli struct.
+// 定义 TimeMilli 结构体
+type TimeMilli struct {
+	Carbon
+}
+
+// TimeMicro defines a TimeMicro struct.
+// 定义 TimeMicro 结构体
+type TimeMicro struct {
+	Carbon
+}
+
+// TimeNano defines a TimeNano struct.
+// 定义 TimeNano 结构体
+type TimeNano struct {
+	Carbon
+}
+
 // DateTime defines a DateTime struct.
 // 定义 DateTime 结构体
 type DateTime struct {
@@ -76,6 +100,94 @@ type TimestampMicro struct {
 // 定义 TimestampNano 结构体
 type TimestampNano struct {
 	Carbon
+}
+
+// MarshalJSON implements the interface json.Marshal for Time struct ("15:04:05").
+// 实现 MarshalJSON 接口
+func (t Time) MarshalJSON() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalJSON implements the interface json.Unmarshal for Time struct ("15:04:05").
+// 实现 UnmarshalJSON 接口
+func (t *Time) UnmarshalJSON(b []byte) error {
+	c := CreateFromTimeLayoutString(string(b))
+	if c.Error == nil {
+		*t = Time{c}
+	}
+	return c.Error
+}
+
+// String implements the interface Stringer for Time struct ("15:04:05").
+// 实现 Stringer 接口
+func (t Time) String() string {
+	return t.ToTimeString()
+}
+
+// MarshalJSON implements the interface json.Marshal for TimeMilli struct ("15:04:05.999").
+// 实现 MarshalJSON 接口
+func (t TimeMilli) MarshalJSON() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalJSON implements the interface json.Unmarshal for TimeMilli struct ("15:04:05.999").
+// 实现 UnmarshalJSON 接口
+func (t *TimeMilli) UnmarshalJSON(b []byte) error {
+	c := CreateFromTimeMilliLayoutString(string(b))
+	if c.Error == nil {
+		*t = TimeMilli{c}
+	}
+	return c.Error
+}
+
+// String implements the interface Stringer for TimeMilli struct ("15:04:05.999").
+// 实现 Stringer 接口
+func (t TimeMilli) String() string {
+	return t.ToTimeMilliString()
+}
+
+// MarshalJSON implements the interface json.Marshal for TimeMicro struct ("15:04:05.999999").
+// 实现 MarshalJSON 接口
+func (t TimeMicro) MarshalJSON() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalJSON implements the interface json.Unmarshal for TimeMicro struct ("15:04:05.999999").
+// 实现 UnmarshalJSON 接口
+func (t *TimeMicro) UnmarshalJSON(b []byte) error {
+	c := CreateFromTimeMicroLayoutString(string(b))
+	if c.Error == nil {
+		*t = TimeMicro{c}
+	}
+	return c.Error
+}
+
+// String implements the interface Stringer for TimeMicro struct ("15:04:05.999999").
+// 实现 Stringer 接口
+func (t TimeMicro) String() string {
+	return t.ToTimeMicroString()
+}
+
+// MarshalJSON implements the interface json.Marshal for TimeNano struct ("15:04:05.999999").
+// 实现 MarshalJSON 接口
+func (t TimeNano) MarshalJSON() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalJSON implements the interface json.Unmarshal for TimeNano struct ("15:04:05.999999").
+// 实现 UnmarshalJSON 接口
+func (t *TimeNano) UnmarshalJSON(b []byte) error {
+	c := CreateFromTimeNanoLayoutString(string(b))
+	if c.Error == nil {
+		*t = TimeNano{c}
+	}
+	return c.Error
+}
+
+// String implements the interface Stringer for TimeNano struct ("15:04:05.999999").
+// 实现 Stringer 接口
+func (t TimeNano) String() string {
+	return t.ToTimeNanoString()
 }
 
 // MarshalJSON implements the interface json.Marshal for DateTime struct.

--- a/json_test.go
+++ b/json_test.go
@@ -23,6 +23,10 @@ type Person struct {
 	CreatedAt2   TimestampMilli `json:"created_at2"`
 	CreatedAt3   TimestampMicro `json:"created_at3"`
 	CreatedAt4   TimestampNano  `json:"created_at4"`
+	Time1        Time           `json:"time1"`
+	Time2        TimeMilli      `json:"time2"`
+	Time3        TimeMicro      `json:"time3"`
+	Time4        TimeNano       `json:"time4"`
 }
 
 var person Person
@@ -43,6 +47,10 @@ func TestCarbon_MarshalJSON(t *testing.T) {
 		CreatedAt2:   TimestampMilli{Parse("2024-08-05 13:14:15.999")},
 		CreatedAt3:   TimestampMicro{Parse("2025-08-05 13:14:15.999999")},
 		CreatedAt4:   TimestampNano{Parse("2025-08-05 13:14:15.999999999")},
+		Time1:        Time{Parse("15:04:05")},
+		Time2:        TimeMilli{Parse("15:04:05.999")},
+		Time3:        TimeMicro{Parse("15:04:05.999999")},
+		Time4:        TimeNano{Parse("15:04:05.999999999")},
 	}
 	data, err := json.Marshal(&person)
 	assert.Nil(t, err)
@@ -64,7 +72,11 @@ func TestCarbon_UnmarshalJSON(t *testing.T) {
 		"created_at1": 1596604455,
 		"created_at2": 1596604455999,
 		"created_at3": 1596604455999999,
-		"created_at4": 1596604455999999999
+		"created_at4": 1596604455999999999,
+		"time1": "15:04:05",
+		"time2": "15:04:05.999",
+		"time3": "15:04:05.999999",
+		"time4": "15:04:05.999999999",
 	}`
 
 	err := json.Unmarshal([]byte(str), &person)
@@ -87,7 +99,11 @@ func TestError_Json(t *testing.T) {
 		"created_at1": 0,
 		"created_at2": 0,
 		"created_at3": 0,
-		"created_at4": 0
+		"created_at4": 0,
+		"time1": "",
+		"time2": "",
+		"time3": "",
+		"time4": "",
 	}`
 	err := json.Unmarshal([]byte(str), &person)
 	assert.NotNil(t, err)

--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,7 @@ import (
 // 将标准格式时间字符串解析成 Carbon 实例
 func (c Carbon) Parse(value string, timezone ...string) Carbon {
 	layouts := []string{
+		TimeLayout, TimeMilliLayout, TimeMicroLayout, TimeNanoLayout,
 		DayDateTimeLayout,
 		DateTimeLayout, DateTimeNanoLayout, ShortDateTimeLayout, ShortDateTimeNanoLayout,
 		DateLayout, DateNanoLayout, ShortDateLayout, ShortDateNanoLayout,


### PR DESCRIPTION
Added support for string-layouts to use Carbon in cases where only needs to use times (like clock, duration, etc.).
[TimeLayout, TimeMilliLayout, TimeMicroLayout, TimeNanoLayout]

