### PR TITLE
Fix integer overflow converting Lunar to Gregorian on 386 arch

### DIFF
--- a/calendar/lunar/lunar.go
+++ b/calendar/lunar/lunar.go
@@ -144,8 +144,8 @@ func (l Lunar) ToGregorian() (g Gregorian) {
 		offset += days
 	}
 
-	ts := (offset+l.day)*86400 + -2206512000 + l.hour*3600 + l.minute*60 + l.second
-	g.Time = time.Unix(int64(ts), 0)
+	ts := (int64(offset)+int64(l.day))*86400 + int64(-2206512000) + int64(l.hour)*3600 + int64(l.minute)*60 + int64(l.second)
+	g.Time = time.Unix(ts, 0)
 	return g
 }
 


### PR DESCRIPTION
`GOARCH=386`

Fix: #219