### PR TITLE
Update the minimum version of Go required to 1.17

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.16.0'
-          
+          go-version: '>=1.17.0'
+
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Create coverage file
         run: go test -coverprofile='coverage.txt' -covermode=atomic
 

--- a/README.cn.md
+++ b/README.cn.md
@@ -18,7 +18,7 @@
 
 #### 安装使用
 
-##### Golang 版本大于等于 1.16 (推荐)
+##### Golang 版本大于等于 1.17 (推荐)
 
 ```go
 // 使用 github 库
@@ -32,7 +32,7 @@ go get -u gitee.com/golang-module/carbon/v2
 import "gitee.com/golang-module/carbon/v2"
 ```
 
-##### Golang 版本小于 1.16 (必须)
+##### Golang 版本小于 1.17 (必须)
 
 ```go
 // 使用 github 库
@@ -1599,7 +1599,7 @@ invalid timezone "xxx", please see the file "$GOROOT/lib/time/zoneinfo.zip" for 
 1、v1 和 v2 版本有什么区别？
 > v1 和 v2 版本的 API 没有任何区别，只是 `language.go` 里翻译资源文件内嵌的实现方式不同，v1 版本是由第三方扩展库 [packr](https://github.com/gobuffalo/packr)
 > 实现的，
-> v2 版本是由 `golang1.16` 后内置标准库 [embed](https://pkg.go.dev/embed) 实现的。如果你的 go 版本大于 1.16推荐使用 v2 版本，否则必须使用 v1 版本。
+> v2 版本是由 `golang1.17` 后内置标准库 [embed](https://pkg.go.dev/embed) 实现的。如果你的 go 版本大于 1.17推荐使用 v2 版本，否则必须使用 v1 版本。
 
 2、window 系统下部署二进制文件时区报错
 

--- a/README.jp.md
+++ b/README.jp.md
@@ -20,7 +20,7 @@ Carbon は [awesome-go](https://github.com/avelino/awesome-go#date-and-time "awe
 
 #### インストール使用
 
-##### Golangバージョンは1.16以上です (推奨)
+##### Golangバージョンは1.17以上です (推奨)
 
 ```go
 // github倉庫を使う
@@ -35,7 +35,7 @@ go get -u gitee.com/golang-module/carbon/v2
 import "gitee.com/golang-module/carbon/v2"
 ```
 
-##### Golangバージョンは1.16より小さいです (必要)
+##### Golangバージョンは1.17より小さいです (必要)
 
 ```go
 // github倉庫を使う
@@ -1599,8 +1599,8 @@ invalid timezone "xxx", please see the file "$GOROOT/lib/time/zoneinfo.zip" for 
 
 1、v1とv2のバージョンの違いは何ですか？
 > APIのv1バージョンとv2バージョンに違いはありませんが `language.go`
-> での翻訳リソースファイルの実装は異なります。v1は、サードパーティの拡張ライブラリ [packr](https://github.com/gobuffalo/packr) によって実装されています，v2は、 `golang1.16`
-> の後に組み込みの標準ライブラリ [embed](https://pkg.go.dev/embed) によって実装されています。goバージョンが1.16より大きい場合は、v2バージョンを使用することをお勧めします。それ以外の場合は、v1バージョンを使用する必要があります。
+> での翻訳リソースファイルの実装は異なります。v1は、サードパーティの拡張ライブラリ [packr](https://github.com/gobuffalo/packr) によって実装されています，v2は、 `golang1.17`
+> の後に組み込みの標準ライブラリ [embed](https://pkg.go.dev/embed) によって実装されています。goバージョンが1.17より大きい場合は、v2バージョンを使用することをお勧めします。それ以外の場合は、v1バージョンを使用する必要があります。
 
 #### 参考文献
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by [awesome-go](https://github.com/avelino/awesome-go#date-and-time "awesome-go"
 
 #### Installation
 
-##### Go version >= 1.16 (recommend)
+##### Go version >= 1.17 (recommend)
 
 ```go
 // By github
@@ -35,7 +35,7 @@ go get -u gitee.com/golang-module/carbon/v2
 import "gitee.com/golang-module/carbon/v2"
 ```
 
-##### Go version < 1.16 (must)
+##### Go version < 1.17 (must)
 
 ```go
 // By github
@@ -1599,7 +1599,7 @@ invalid timezone "xxx", please see the file "$GOROOT/lib/time/zoneinfo.zip" for 
 #### FAQ
 
 1、What is the difference between v1 and v2?
-> There is no difference between v1 and v2 of the API, but the implementation of the translation resource files in `language.go` is different. The v1 is implemented by the third-party extension library [packr](https://github.com/gobuffalo/packr), and the v2 is implemented by the standard library [embed](https://pkg.go.dev/embed) after `golang1.16`. If your golang version is `1.16+`, the v2 is recommended, otherwise, the v1 is required.
+> There is no difference between v1 and v2 of the API, but the implementation of the translation resource files in `language.go` is different. The v1 is implemented by the third-party extension library [packr](https://github.com/gobuffalo/packr), and the v2 is implemented by the standard library [embed](https://pkg.go.dev/embed) after `golang1.17`. If your golang version is `1.17+`, the v2 is recommended, otherwise, the v1 is required.
 
 #### References
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/golang-module/carbon/v2
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
The `time.IsDST` and `time.GoString` functions that are dependent on in the `comparer.go` and `outputer.go` files require Go version 1.17 to support.